### PR TITLE
Fix reinject message issue: do not add Hubot as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-vso-scripts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Hubot Visual Studio Online Scripts",
   "main": "./src/vsonline-scripts",
   "scripts": {
@@ -24,7 +24,6 @@
   "homepage": "https://github.com/scrumdod/vso-hubotscripts",
   "dependencies": {
     "node-uuid": "~1.4.1",
-    "hubot": "~2.7.5",
     "vso-client": "~0.1.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,6 @@ application in Visual Studio Online
 
 ### License
 
-TODO
+MIT
 
 


### PR DESCRIPTION
Removed the Hubot as a dependency since when doing 

`{TextMessage} = require 'hubot'` 

we got a different one different from one that is loaded, therefore listeners fail to work (somewhere there is a check `if message instanceof TextMessage` that fails when TextMessage is loaded from another location.)

(http://stackoverflow.com/questions/21707472/why-does-require-give-me-a-new-copy-of-a-module-when-loaded-from-a-different-l)

Thanks to @spajus figuring out the problem
